### PR TITLE
Sett opp Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,10 @@
 version: 2
+registries:
+  familie-felles:
+    type: maven-repository
+    url: https://maven.pkg.github.com/navikt/familie-felles
+    username: x-access-token
+    password: "${{secrets.NPM_AUTH_TOKEN}}"
 updates:
   - package-ecosystem: npm
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "12:00"
+      timezone: "Europe/Oslo"
+    open-pull-requests-limit: 5
+    ignore:
+    - dependency-name: "*"
+      update-types: ["version-update:semver-patch"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 registries:
   familie-felles:
     type: maven-repository
-    url: https://maven.pkg.github.com/navikt/familie-felles
+    url: https://maven.pkg.github.com/navikt
     username: x-access-token
     password: "${{secrets.NPM_AUTH_TOKEN}}"
 updates:


### PR DESCRIPTION
# Hva?

Dependabot er et verktøy som automatiserer at pakker blir oppdatert riktig. 
Den lager kun PRer som man må manuelt gå igjennom og godkjenne for å få endringer. Dette gjer det mulig at man kan teste om ny pakke versjon krever 

Dependaboten vil blandt annet: 

- Si i fra når pakker bør oppdateres. [Link til relevant artikkel her.](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/)
- Si i fra når pakker har sårbarheter og skal oppdateres.  [Link til Github docs for Dependabot Security Updates](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates)
- Oppdage sikkerhetshull i koden og forslå endringer for å skrive sikker kode. [Mer info her](https://github.com/features/security)

Fordeler med å bruke Dependabot:

- **Stabilitet**: Alltid oppdatert til riktig pakker
- **Sikkerhet**: Pakker med sårbarheter blir funnet og oppdatert
- **Vedlikehold**: Enkelt vedlikehold flere pakker. Veldig nytting i større project. 


[Link til trello kort og les mer om Dependabot her.](https://trello.com/c/XHIjUj1s/44-f%C3%A5-opp-dependabot)

[Link til PR i bekk/nav-familie-endringsmelding som har samme mål](https://github.com/bekk/nav-familie-endringsmelding/pull/48)

# Hvordan? 

Fekk admin tilgang og satt opp det i Github. 
Deretter la til et script for hvor ofte pakkene skal bli sett. 
Vi bestemte for å gjør dette kl. 12 hver dag og kvar 5 pull request som limit. 

Her er bilde fra Github:
![image](https://github.com/bekk/nav-familie-endringsmelding-api/assets/66110094/46708aa8-125a-42bb-8478-4d3b3391882f)


