### PR TITLE
Flytt endringsmelding filer i egen pakke

### DIFF
--- a/src/main/kotlin/no/nav/familie/endringsmelding/endringsmelding/EndringsmeldingController.kt
+++ b/src/main/kotlin/no/nav/familie/endringsmelding/endringsmelding/EndringsmeldingController.kt
@@ -1,8 +1,8 @@
-package no.nav.familie.endringsmelding.api
+package no.nav.familie.endringsmelding.endringsmelding
 
+import no.nav.familie.endringsmelding.api.ApiFeil
 import no.nav.familie.endringsmelding.api.dto.Kvittering
 import no.nav.familie.endringsmelding.featuretoggle.FeatureToggleService
-import no.nav.familie.endringsmelding.service.EndringsmeldingService
 import no.nav.familie.sikkerhet.EksternBrukerUtils
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.security.token.support.core.api.RequiredIssuers
@@ -21,7 +21,7 @@ import java.time.LocalDateTime
     ProtectedWithClaims(issuer = EksternBrukerUtils.ISSUER_TOKENX, claimMap = ["acr=Level4"]),
 )
 @Validated
-class InnsendingController(val endringsmeldingService: EndringsmeldingService, val featureToggleService: FeatureToggleService) {
+class EndringsmeldingController(val endringsmeldingService: EndringsmeldingService, val featureToggleService: FeatureToggleService) {
 
     @PostMapping(path = ["/ba"])
     fun sendInn(@RequestBody endringsmelding: String): Kvittering {

--- a/src/main/kotlin/no/nav/familie/endringsmelding/endringsmelding/EndringsmeldingService.kt
+++ b/src/main/kotlin/no/nav/familie/endringsmelding/endringsmelding/EndringsmeldingService.kt
@@ -1,4 +1,4 @@
-package no.nav.familie.endringsmelding.service
+package no.nav.familie.endringsmelding.endringsmelding
 
 import no.nav.familie.endringsmelding.api.dto.Kvittering
 import no.nav.familie.endringsmelding.integration.BaMottakClient

--- a/src/test/kotlin/no/nav/familie/endringsmelding/api/EndringsmeldingControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/endringsmelding/api/EndringsmeldingControllerTest.kt
@@ -5,7 +5,7 @@ import io.mockk.mockk
 import no.nav.familie.endringsmelding.api.dto.Kvittering
 import no.nav.familie.endringsmelding.featuretoggle.FeatureToggleService
 import no.nav.familie.endringsmelding.integrationTest.OppslagSpringRunnerTest
-import no.nav.familie.endringsmelding.service.EndringsmeldingService
+import no.nav.familie.endringsmelding.endringsmelding.EndringsmeldingService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test


### PR DESCRIPTION
### Hvorfor?

Flyttet pakker til å bruke feature based mappe stuktur.
Trenger kanskje egen PR på å flytte alt over slik at samme struktur blir brukt på alt. 
Har brukt layered based, men bestemte oss for å bytte til feature based for endringsmelding 🤩
