### PR TITLE
Ta inn objekt med endringsmelding

### DIFF
--- a/src/main/kotlin/no/nav/familie/endringsmelding/endringsmelding/Endringsmelding.kt
+++ b/src/main/kotlin/no/nav/familie/endringsmelding/endringsmelding/Endringsmelding.kt
@@ -1,0 +1,6 @@
+package no.nav.familie.endringsmelding.endringsmelding
+
+data class Endringsmelding(
+        val tekst: String,
+        val dokumenter: List<String>? = emptyList()
+)

--- a/src/main/kotlin/no/nav/familie/endringsmelding/endringsmelding/EndringsmeldingController.kt
+++ b/src/main/kotlin/no/nav/familie/endringsmelding/endringsmelding/EndringsmeldingController.kt
@@ -23,17 +23,11 @@ import java.time.LocalDateTime
 @Validated
 class EndringsmeldingController(val endringsmeldingService: EndringsmeldingService, val featureToggleService: FeatureToggleService) {
 
-    data class Endringsmelding(
-            val tekst: String,
-            val dokumenter: List<String>? = emptyList()
-    )
-
     @PostMapping(path = ["/ba"])
     fun sendInn(@RequestBody endringsmelding: Endringsmelding): Kvittering {
         if (!featureToggleService.isEnabled("familie.endringsmelding.send-inn")) {
             throw ApiFeil("Kan ikke sende inn endringsmelding - funksjonen er ikke aktivert", HttpStatus.BAD_REQUEST)
         }
-
         val innsendingMottatt = LocalDateTime.now()
         return endringsmeldingService.sendInnBa(endringsmelding.tekst, innsendingMottatt)
     }

--- a/src/main/kotlin/no/nav/familie/endringsmelding/endringsmelding/EndringsmeldingController.kt
+++ b/src/main/kotlin/no/nav/familie/endringsmelding/endringsmelding/EndringsmeldingController.kt
@@ -16,28 +16,34 @@ import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDateTime
 
 @RestController
-@RequestMapping(path = ["/api/send-inn"], produces = [APPLICATION_JSON_VALUE])
+@RequestMapping(path = ["/api/send-inn"], produces = [APPLICATION_JSON_VALUE], consumes = [APPLICATION_JSON_VALUE])
 @RequiredIssuers(
     ProtectedWithClaims(issuer = EksternBrukerUtils.ISSUER_TOKENX, claimMap = ["acr=Level4"]),
 )
 @Validated
 class EndringsmeldingController(val endringsmeldingService: EndringsmeldingService, val featureToggleService: FeatureToggleService) {
 
+    data class Endringsmelding(
+            val tekst: String,
+            val dokumenter: List<String>? = emptyList()
+    )
+
     @PostMapping(path = ["/ba"])
-    fun sendInn(@RequestBody endringsmelding: String): Kvittering {
+    fun sendInn(@RequestBody endringsmelding: Endringsmelding): Kvittering {
         if (!featureToggleService.isEnabled("familie.endringsmelding.send-inn")) {
             throw ApiFeil("Kan ikke sende inn endringsmelding - funksjonen er ikke aktivert", HttpStatus.BAD_REQUEST)
         }
+
         val innsendingMottatt = LocalDateTime.now()
-        return endringsmeldingService.sendInnBa(endringsmelding, innsendingMottatt)
+        return endringsmeldingService.sendInnBa(endringsmelding.tekst, innsendingMottatt)
     }
 
     @PostMapping(path = ["/ks"])
-    fun sendInnKs(@RequestBody endringsmelding: String): Kvittering {
+    fun sendInnKs(@RequestBody endringsmelding: Endringsmelding): Kvittering {
         if (!featureToggleService.isEnabled("familie.endringsmelding.send-inn")) {
             throw ApiFeil("Kan ikke sende inn endringsmelding - funksjonen er ikke aktivert", HttpStatus.BAD_REQUEST)
         }
         val innsendingMottatt = LocalDateTime.now()
-        return endringsmeldingService.sendInnKs(endringsmelding, innsendingMottatt)
+        return endringsmeldingService.sendInnKs(endringsmelding.tekst, innsendingMottatt)
     }
 }

--- a/src/main/kotlin/no/nav/familie/endringsmelding/endringsmelding/EndringsmeldingService.kt
+++ b/src/main/kotlin/no/nav/familie/endringsmelding/endringsmelding/EndringsmeldingService.kt
@@ -16,7 +16,7 @@ class EndringsmeldingService(
         private val ksMottakClient: KsMottakClient,
 ) {
 
-    val SPESIAL_TEGN_REGEX = Regex("^[a-zA-ZæøåÆØÅ0-9.,:!?@% ]+$")
+    val INGEN_SPESIALTEGN_REGEX = Regex("^[a-zA-Z0-9æøåÆØÅ.,:!?@% ]+$")
 
     fun validerEndringsmelding(endringsmelding: String) {
 
@@ -32,7 +32,7 @@ class EndringsmeldingService(
             throw ApiFeil(EndringsmeldingFeil.MINDRE_ENN_TI_TEGN.toString(), HttpStatus.BAD_REQUEST)
         }
 
-        if (!endringsmelding.matches(SPESIAL_TEGN_REGEX)) {
+        if (!endringsmelding.matches(INGEN_SPESIALTEGN_REGEX)) {
             throw ApiFeil(EndringsmeldingFeil.HAR_SPESIAL_TEGN.toString(), HttpStatus.BAD_REQUEST)
         }
 
@@ -60,6 +60,7 @@ class EndringsmeldingService(
             endringsmelding: String,
             innsendingMottatt: LocalDateTime,
     ): Kvittering {
+        validerEndringsmelding(endringsmelding)
         val kvittering = ksMottakClient.sendInn(endringsmelding)
         return Kvittering(kvittering.text, innsendingMottatt)
     }

--- a/src/test/kotlin/no/nav/familie/endringsmelding/endringsmelding/EndringsmeldingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/endringsmelding/endringsmelding/EndringsmeldingServiceTest.kt
@@ -12,13 +12,13 @@ class EndringsmeldingServiceTest {
 
     @Test
     fun `skal validere med alle godkjente tegn`() {
-        val endringsmeldingService = EndringsmeldingService(mockk(), mockk())
+        val endringsmeldingService = EndringsmeldingService(mockk(), mockk(), mockk())
         endringsmeldingService.validerEndringsmelding("Denne skal fungere: Hvorfor? @charlie.  Flere tegn: ÆØÅ.,%. Tall: 1234567890")
     }
 
     @Test
     fun `skal feile med ingen tekst`() {
-        val endringsmeldingService = EndringsmeldingService(mockk(), mockk())
+        val endringsmeldingService = EndringsmeldingService(mockk(), mockk(), mockk())
 
         val feil = assertThrows<ApiFeil> {
             endringsmeldingService.validerEndringsmelding("")
@@ -30,7 +30,7 @@ class EndringsmeldingServiceTest {
 
     @Test
     fun `skal feile med tekst mer enn 1000 tegn`() {
-        val endringsmeldingService = EndringsmeldingService(mockk(), mockk())
+        val endringsmeldingService = EndringsmeldingService(mockk(), mockk(), mockk())
 
         val FOR_LANG_MELDING = """
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed consectetur a ex quis ultricies. Donec tincidunt fermentum eros, ut efficitur massa dictum eu. Morbi ac pellentesque justo. Integer cursus magna metus. Pellentesque eleifend enim est, sed semper ante pretium nec. Nulla scelerisque, elit sed varius hendrerit, urna ex rutrum urna, vel malesuada diam justo et eros. Maecenas et ornare mi. Nam pharetra in elit quis eleifend. Vestibulum mollis nisi eu quam pharetra, vel vestibulum diam consequat. Vivamus commodo, libero consequat laoreet pellentesque, nisi quam ultricies dui, id egestas mauris urna at quam. Aliquam ipsum ligula, venenatis eu gravida ac, luctus pharetra elit. Nunc feugiat nibh rhoncus arcu sagittis, et sodales sapien elementum. Sed bibendum lectus sed magna maximus vestibulum.
@@ -61,7 +61,7 @@ class EndringsmeldingServiceTest {
 
     @Test
     fun `skal feile med tekst mindre enn 10 tegn`() {
-        val endringsmeldingService = EndringsmeldingService(mockk(), mockk())
+        val endringsmeldingService = EndringsmeldingService(mockk(), mockk(), mockk())
 
         val feil = assertThrows<ApiFeil> {
             endringsmeldingService.validerEndringsmelding("123456789")
@@ -73,7 +73,7 @@ class EndringsmeldingServiceTest {
 
     @Test
     fun `skal feile med spesialtegn som ikke er tillat`() {
-        val endringsmeldingService = EndringsmeldingService(mockk(), mockk())
+        val endringsmeldingService = EndringsmeldingService(mockk(), mockk(), mockk())
 
         val feil = assertThrows<ApiFeil> {
             endringsmeldingService.validerEndringsmelding("Denne ikke () skal fungere")


### PR DESCRIPTION
Vi fikk feil etter å ha lagt inn validering der responsen fra backenden sa at det var spesialtegn i endringsmeldingen selvom det ikke var det. Det viste seg å være fordi stringen som ble sendt inn til validering var på formatet ""Dette er en endringesmelding"", som gjorde at teksten ble validert som med spesialtegn ettersom " ikke er lov. 

Egen PR i frontend som tar for seg endringen til å sende et objekt, mens endringene her er for å håndtere at man tar inn objektet fra frontenden. I tillegg la vi til feltet for dokumenter når vi først lagde et objekt ettersom dette vil bli brukt i dokumentopplastning nå snart. 