### PR TITLE
Skal ta inn dokumenter

### DIFF
--- a/src/main/kotlin/no/nav/familie/endringsmelding/endringsmelding/Endringsmelding.kt
+++ b/src/main/kotlin/no/nav/familie/endringsmelding/endringsmelding/Endringsmelding.kt
@@ -1,6 +1,0 @@
-package no.nav.familie.endringsmelding.endringsmelding
-
-data class Endringsmelding(
-        val tekst: String,
-        val dokumenter: List<String>? = emptyList()
-)

--- a/src/main/kotlin/no/nav/familie/endringsmelding/endringsmelding/EndringsmeldingController.kt
+++ b/src/main/kotlin/no/nav/familie/endringsmelding/endringsmelding/EndringsmeldingController.kt
@@ -24,20 +24,26 @@ import java.time.LocalDateTime
 class EndringsmeldingController(val endringsmeldingService: EndringsmeldingService, val featureToggleService: FeatureToggleService) {
 
     @PostMapping(path = ["/ba"])
-    fun sendInn(@RequestBody endringsmelding: Endringsmelding): Kvittering {
+    fun sendInn(@RequestBody endringsmelding: EndringsmeldingPayload): Kvittering {
         if (!featureToggleService.isEnabled("familie.endringsmelding.send-inn")) {
             throw ApiFeil("Kan ikke sende inn endringsmelding - funksjonen er ikke aktivert", HttpStatus.BAD_REQUEST)
         }
+        val endringsmeldingDto = EndringsmeldingDto(tekst = endringsmelding.tekst, dokumenter = endringsmelding.dokumenter.split(","))
+        println("Dokumenter som skal bli sendt videre herifra" + endringsmeldingDto.dokumenter)
+
         val innsendingMottatt = LocalDateTime.now()
-        return endringsmeldingService.sendInnBa(endringsmelding.tekst, innsendingMottatt)
+        return endringsmeldingService.sendInnBa(endringsmeldingDto.tekst, innsendingMottatt)
     }
 
     @PostMapping(path = ["/ks"])
-    fun sendInnKs(@RequestBody endringsmelding: Endringsmelding): Kvittering {
+    fun sendInnKs(@RequestBody endringsmelding: EndringsmeldingPayload): Kvittering {
         if (!featureToggleService.isEnabled("familie.endringsmelding.send-inn")) {
             throw ApiFeil("Kan ikke sende inn endringsmelding - funksjonen er ikke aktivert", HttpStatus.BAD_REQUEST)
         }
+        val endringsmeldingDto = EndringsmeldingDto(tekst = endringsmelding.tekst, dokumenter = endringsmelding.dokumenter.split(","))
+        println("Dokumenter som skal bli sendt videre herifra" + endringsmeldingDto.dokumenter)
+
         val innsendingMottatt = LocalDateTime.now()
-        return endringsmeldingService.sendInnKs(endringsmelding.tekst, innsendingMottatt)
+        return endringsmeldingService.sendInnKs(endringsmeldingDto.tekst, innsendingMottatt)
     }
 }

--- a/src/main/kotlin/no/nav/familie/endringsmelding/endringsmelding/EndringsmeldingDto.kt
+++ b/src/main/kotlin/no/nav/familie/endringsmelding/endringsmelding/EndringsmeldingDto.kt
@@ -1,0 +1,12 @@
+package no.nav.familie.endringsmelding.endringsmelding
+
+//TODO: Kan man gjøre dette på en lurere måte?
+data class EndringsmeldingPayload(
+        val tekst: String,
+        val dokumenter: String
+)
+
+data class EndringsmeldingDto(
+        val tekst: String,
+        val dokumenter: List<String>? = emptyList()
+)

--- a/src/main/kotlin/no/nav/familie/endringsmelding/mock/PdlClientConfigFly.kt
+++ b/src/main/kotlin/no/nav/familie/endringsmelding/mock/PdlClientConfigFly.kt
@@ -51,7 +51,7 @@ class PdlClientConfigFly {
     }
 
     private fun lagNavn(
-        fornavn: String = "Fornavn",
+        fornavn: String = "Askeladden",
         mellomnavn: String? = "mellomnavn",
         etternavn: String = "Etternavn",
     ): List<Navn> =


### PR DESCRIPTION
`sendInn` endepunktet tar inn en string for teksten til endringsmeldingen og skal nå også kunne ta i mot en string med dokument id-er som splittes opp og legges i en liste. 

Det er laget en ny data class EndringsmeldingPayload for payloaden som kommer i requesten med en string av dokumenter. Denne stringen blir så splittet på "," til en liste. 

Legg merke til at ettersom dokumentene blir sendt som en string med id-er satt sammen med "," avslutter listen med et komma (se println). En bedre løsning kunne for eksempel vært at man fikk til å sende et objekt fra frontend med tekst og dokumenter som blir serialized og deserialized feks. På grunn av litt lite tid på slutten fikk vi dessverre ikke begynt på dette 😢 En lenke som ble brukt for litt inspirasjon til dette: https://plainenglish.io/blog/how-to-append-javascript-data-to-a-formdata

PS: Fornavn er også endret til Askeladden i mock, så da er vi klare for demooo